### PR TITLE
Fix #28: Adding enemy spawner

### DIFF
--- a/bring_ur_glam/src/Actors/Enemy.gd
+++ b/bring_ur_glam/src/Actors/Enemy.gd
@@ -8,6 +8,8 @@ export var JUMP_POWER = -250
 export var HP = 3
 export (PackedScene) var BULLET
 
+signal died
+
 const FLOOR = Vector2(0, -1)
 
 
@@ -44,6 +46,7 @@ func hurt():
         $CollisionShape2D.set_deferred("disabled", true)
         $DeathTimer.start()
         $Sprite.flip_v = true
+        emit_signal("died")
 
 func _physics_process(delta):
     if HP <= 0:

--- a/bring_ur_glam/src/Levels/Playground.gd
+++ b/bring_ur_glam/src/Levels/Playground.gd
@@ -1,0 +1,68 @@
+extends Node2D
+
+var Enemy = load("res://src/Actors/Enemy.tscn")
+var enemiesInScreen = 1
+var enemiesKilled = 0
+var liveEnemies = 0
+
+
+func _on_enemyDied() -> void:
+    enemiesKilled += 1
+    liveEnemies -= 1
+    updateNumberOfEnemiesInScreen()
+
+
+func updateNumberOfEnemiesInScreen() -> void:
+    enemiesInScreen = 1 if enemiesKilled <= 1 else ceil(log(enemiesKilled) / log(2))
+    
+
+func getFloorXBoundaries() -> Array:
+    var floorMap = $WalkingPath
+    var floorMapRect = floorMap.get_used_rect()
+    
+    return [floorMapRect.position.x * floorMap.cell_size.x + floorMap.position.x,
+        floorMapRect.end.x * floorMap.cell_size.x + floorMap.position.x]
+    
+
+func getNewEnemyPosition(enemy: Enemy) -> Vector2:
+    var floorXBoundaries = getFloorXBoundaries()
+    var floorLeftLimit = floorXBoundaries[0]
+    var floorRightLimit = floorXBoundaries[1]
+    
+    var viewportRect = get_viewport().get_visible_rect()
+    var viewportOffset = abs(viewportRect.position.x - viewportRect.end.x)/2
+
+    var spawnToLeft = (randi() % 2) == 0
+    var posX = 0
+    if spawnToLeft:
+        posX = rand_range(floorLeftLimit, $Player.position.x - viewportOffset)
+    else:
+        posX = rand_range($Player.position.x + viewportOffset, floorRightLimit)
+
+    var posY = $Player/Camera2D.limit_top
+    
+    return Vector2(posX, posY)
+
+
+func instanceEnemy() -> void:
+    var enemy = Enemy.instance()
+    add_child(enemy)
+    liveEnemies += 1
+
+    enemy.position = getNewEnemyPosition(enemy)
+    enemy.connect("died", self, "_on_enemyDied")
+    enemy.move_and_collide(Vector2(0, 1000))
+
+
+func checkAndInstanceEnemies():
+    if liveEnemies == 0:
+        for n in enemiesInScreen:
+            instanceEnemy()
+
+
+func _ready() -> void:
+    randomize()
+
+
+func _process(delta) -> void:
+    checkAndInstanceEnemies()

--- a/bring_ur_glam/src/Levels/Playground.tscn
+++ b/bring_ur_glam/src/Levels/Playground.tscn
@@ -1,14 +1,15 @@
 [gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://assets/Prototype-test.tres" type="TileSet" id=1]
+[ext_resource path="res://src/Levels/Playground.gd" type="Script" id=2]
 [ext_resource path="res://assets/Prototype.tres" type="TileSet" id=3]
 [ext_resource path="res://src/UserInterface/PauseScreen.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/Actors/Player.tscn" type="PackedScene" id=5]
 [ext_resource path="res://assets/bg.png" type="Texture" id=6]
 [ext_resource path="res://assets/tree.png" type="Texture" id=7]
-[ext_resource path="res://src/Actors/Enemy.tscn" type="PackedScene" id=8]
 
 [node name="Playground" type="Node2D"]
+script = ExtResource( 2 )
 
 [node name="Sky" type="ParallaxBackground" parent="."]
 
@@ -98,6 +99,3 @@ tile_data = PoolIntArray( 458811, 10, 0, 786411, 10, 0 )
 __meta__ = {
 "_editor_description_": ""
 }
-
-[node name="Enemy" parent="." instance=ExtResource( 8 )]
-position = Vector2( -701.745, 152.188 )


### PR DESCRIPTION
Spawns enemies onto the Playground screen in a position that is over the floor tileset, but not within the player viewport, so they appear "off-screen".
They also spawn high above the camera top limit but are dragged down up to floor collision (should simplify when we have buildings affecting the y position).

The spawn logic starts with a single enemy then increases to the log of 2, based on the amount of enemies killed.